### PR TITLE
Add simple notepad page

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@
         <a href="#checkout" class="btn">Invista Agora</a>
     </section>
 
+    <!-- Notepad Section -->
+    <section class="cta">
+        <h2>Precisa fazer anotações?</h2>
+        <p>Acesse o <a href="notepad.html">Bloco de Notas</a> e registre suas ideias.</p>
+    </section>
+
     <!-- Footer -->
     <footer>
         <p>&copy; 2025 CriptoInvestimentos. Todos os direitos reservados.</p>

--- a/notepad.html
+++ b/notepad.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bloco de Notas</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+        }
+        textarea {
+            width: 100%;
+            height: 200px;
+            padding: 10px;
+            box-sizing: border-box;
+        }
+        button {
+            margin-top: 10px;
+            padding: 10px 20px;
+            font-size: 1rem;
+        }
+    </style>
+</head>
+<body>
+    <h1>Bloco de Notas</h1>
+    <form>
+        <textarea id="notes" placeholder="Digite suas anotações aqui..."></textarea>
+        <br>
+        <button type="button" id="saveBtn">Salvar</button>
+    </form>
+    <script>
+        const textarea = document.getElementById('notes');
+        const STORAGE_KEY = 'notepadText';
+
+        // Carregar anotações salvas
+        textarea.value = localStorage.getItem(STORAGE_KEY) || '';
+
+        document.getElementById('saveBtn').addEventListener('click', () => {
+            localStorage.setItem(STORAGE_KEY, textarea.value);
+            alert('Anotações salvas!');
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `notepad.html` with a textarea and save button
- persist notes using `localStorage`
- link to the notepad page in the README

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687413c9abd483269da55f13e6149db4